### PR TITLE
Fix to deserialize nested references to objects even when the references are not detected as 'circular'.

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -76,16 +76,16 @@ exports.unserialize = function(obj, originObj) {
         } else if(obj[key].indexOf(CIRCULARFLAG) === 0) {
           obj[key] = obj[key].substring(CIRCULARFLAG.length);
           circularTasks.push({obj: obj, key: key});
+        }else if (obj[key].indexOf(KEYPATHSEPARATOR) > -1) {
+          circularTasks.push({obj: obj, key: key});
         }
       }
     }
   }
 
-  if (isIndex) {
-    circularTasks.forEach(function(task) {
-      task.obj[task.key] = getKeyPath(originObj, task.obj[task.key]);
-    });
-  }
+  circularTasks.forEach(function(task) {
+    task.obj[task.key] = getKeyPath(originObj, task.obj[task.key]);
+  });
   return obj;
 };
 


### PR DESCRIPTION
For example:

{
 x: {},
 y: { z: <<ref $.x>> }
}

Without this patch, z would not get deserialized correctly. With it, it
does.